### PR TITLE
Find nearestPair more efficiently.

### DIFF
--- a/src/hcluster.js
+++ b/src/hcluster.js
@@ -163,7 +163,13 @@ var hcluster = function() {
                   clusters[pair[0]].indexes,
                   clusters[pair[1]].indexes ); });
       nearestPair = clusterPairs
-        .sort(function(pairA, pairB) { return pairA[2] - pairB[2]; })[0];
+        .reduce(function(pairA, pairB) {
+          if (pairA[2] <= pairB[2]) {
+            return pairA;
+          } else {
+            return pairB;
+          }
+        }, [0, 0, Infinity]);
       newCluster = {
         name: 'Node ' + iter,
         height: nearestPair[2],


### PR DESCRIPTION
How this works:

Previously, the nearestPair was found by performing an array.sort() and then
picking off the [0]th element. This is functionally correct, but
computationally wasteful since all the extra sorting work done for the rest
of the array is simply thrown out.

Now we use array.reduce() instead to scan through the array once, looking
for the pair with the smallest distance.